### PR TITLE
Visual: Agregando base de interfaz principal y ventana para registrar equipo

### DIFF
--- a/BSMRD/src/logical/Equipo.java
+++ b/BSMRD/src/logical/Equipo.java
@@ -10,6 +10,16 @@ public class Equipo {
 	private int juegosGanados; 
 	private int juegosPerdidos; 
 	private String estadio;
+	public Equipo(String nombre, String entrenador, float presupuesto, String estadio) {
+		super();
+		this.nombre = nombre;
+		this.estadio = estadio;
+		this.entrenador = entrenador;
+		this.presupuesto = presupuesto;
+		this.misJugadores = new ArrayList<>();
+		this.juegosGanados = 0;
+		this.juegosPerdidos = 0;
+	}
 	public Equipo(String nombre, ArrayList<Jugador> misJugadores, String entrenador, float presupuesto,
 			int juegosGanados, int juegosPerdidos, String estadio) {
 		super();

--- a/BSMRD/src/visual/BSM.java
+++ b/BSMRD/src/visual/BSM.java
@@ -1,0 +1,64 @@
+package visual;
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JMenu;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+
+public class BSM extends JFrame {
+
+	private JPanel contentPane;
+
+	/**
+	 * Launch the application.
+	 */
+	public static void main(String[] args) {
+		EventQueue.invokeLater(new Runnable() {
+			public void run() {
+				try {
+					BSM frame = new BSM();
+					frame.setVisible(true);
+					frame.setExtendedState(frame.getExtendedState() | JFrame.MAXIMIZED_BOTH);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		});
+	}
+
+	/**
+	 * Create the frame.
+	 */
+	public BSM() {
+		setTitle("Basketball Statistical Manager RD");
+		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		setBounds(100, 100, 450, 300);
+		
+		JMenuBar menuBar = new JMenuBar();
+		setJMenuBar(menuBar);
+		
+		JMenu mnEquipo = new JMenu("Equipo");
+		menuBar.add(mnEquipo);
+		
+		JMenuItem mntmRegistrar = new JMenuItem("Registrar");
+		mntmRegistrar.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				RegEquipo regEquipo = new RegEquipo();
+				regEquipo.setVisible(true);
+			}
+		});
+		mnEquipo.add(mntmRegistrar);
+		contentPane = new JPanel();
+		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
+		setContentPane(contentPane);
+		contentPane.setLayout(new BorderLayout(0, 0));
+	}
+
+}

--- a/BSMRD/src/visual/RegEquipo.java
+++ b/BSMRD/src/visual/RegEquipo.java
@@ -1,0 +1,152 @@
+package visual;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+import javax.swing.border.TitledBorder;
+
+import logical.Conferencia;
+import logical.Equipo;
+
+import javax.swing.border.BevelBorder;
+import java.awt.Color;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.SoftBevelBorder;
+import javax.swing.border.MatteBorder;
+import javax.swing.JTextField;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import java.awt.Font;
+
+public class RegEquipo extends JDialog {
+
+	private final JPanel contentPanel = new JPanel();
+	private JTextField txtNombre;
+	private JTextField txtEstadio;
+	private JTextField txtEntrenador;
+	private JSpinner spnPresupuesto;
+
+	/**
+	 * Launch the application.
+	 */
+
+	/**
+	 * Create the dialog.
+	 */
+	public RegEquipo() {
+		setTitle("Registrar equipo");
+		setBounds(100, 100, 450, 256);
+		setLocationRelativeTo(null);
+		setModal(true);
+		getContentPane().setLayout(new BorderLayout());
+		contentPanel.setBorder(new MatteBorder(1, 1, 1, 1, (Color) new Color(0, 0, 0)));
+		getContentPane().add(contentPanel, BorderLayout.CENTER);
+		contentPanel.setLayout(new BorderLayout(0, 0));
+		{
+			JPanel panel = new JPanel();
+			panel.setBorder(new TitledBorder(new BevelBorder(BevelBorder.LOWERED, null, null, null, null), "Registro de equipos", TitledBorder.LEADING, TitledBorder.TOP, null, new Color(0, 0, 0)));
+			contentPanel.add(panel, BorderLayout.CENTER);
+			panel.setLayout(null);
+			
+			txtNombre = new JTextField();
+			txtNombre.setBounds(39, 57, 170, 20);
+			panel.add(txtNombre);
+			txtNombre.setColumns(10);
+			
+			txtEstadio = new JTextField();
+			txtEstadio.setBounds(247, 57, 161, 20);
+			panel.add(txtEstadio);
+			txtEstadio.setColumns(10);
+			
+			JLabel lblNombre = new JLabel("Nombre:");
+			lblNombre.setFont(new Font("Dialog", Font.BOLD, 11));
+			lblNombre.setBounds(29, 32, 73, 14);
+			panel.add(lblNombre);
+			
+			JLabel lblEstadio = new JLabel("Estadio:");
+			lblEstadio.setFont(new Font("Dialog", Font.BOLD, 11));
+			lblEstadio.setBounds(237, 32, 73, 14);
+			panel.add(lblEstadio);
+			
+			JLabel lblEntrenador = new JLabel("Entrenador:");
+			lblEntrenador.setFont(new Font("Dialog", Font.BOLD, 11));
+			lblEntrenador.setBounds(29, 104, 73, 14);
+			panel.add(lblEntrenador);
+			
+			JLabel lblPresupuesto = new JLabel("Presupuesto (D\u00F3lares):");
+			lblPresupuesto.setFont(new Font("Dialog", Font.BOLD, 11));
+			lblPresupuesto.setBounds(237, 104, 142, 14);
+			panel.add(lblPresupuesto);
+			
+			txtEntrenador = new JTextField();
+			txtEntrenador.setBounds(39, 129, 170, 20);
+			panel.add(txtEntrenador);
+			txtEntrenador.setColumns(10);
+			
+			spnPresupuesto = new JSpinner();
+			spnPresupuesto.setModel(new SpinnerNumberModel(new Float(100000), new Float(100000), new Float(2147483647), new Float(1000)));
+			spnPresupuesto.setBounds(247, 129, 161, 20);
+			panel.add(spnPresupuesto);
+			
+			JLabel label = new JLabel("$");
+			label.setFont(new Font("Dialog", Font.BOLD, 11));
+			label.setBounds(237, 132, 28, 14);
+			panel.add(label);
+		}
+		{
+			JPanel buttonPane = new JPanel();
+			buttonPane.setLayout(new FlowLayout(FlowLayout.RIGHT));
+			getContentPane().add(buttonPane, BorderLayout.SOUTH);
+			{
+				JButton okButton = new JButton("Registrar");
+				okButton.addActionListener(new ActionListener() {
+					public void actionPerformed(ActionEvent e) {
+						try {
+							String nombre = txtNombre.getText().toString();
+							String estadio = txtEstadio.getText().toString();
+							String entrenador = txtEntrenador.getText().toString();
+							float presupuesto = Float.parseFloat(spnPresupuesto.getValue().toString());
+							if(nombre.isEmpty() | estadio.isEmpty() | entrenador.isEmpty()) {
+								throw new Exception();
+							}
+							Equipo equipo = new Equipo(nombre, entrenador, presupuesto, estadio);
+							Conferencia.getInstance().insertEquipo(equipo);
+							JOptionPane.showMessageDialog(null, "Operación satisfactoria.", "Información", JOptionPane.INFORMATION_MESSAGE);
+							clear();
+						} catch (Exception e2) {
+							System.out.println(e2);
+							JOptionPane.showMessageDialog(null, "Asegúrese de que sus datos están correctos.", "Error", JOptionPane.ERROR_MESSAGE);
+						}
+					}
+				});
+				okButton.setActionCommand("OK");
+				buttonPane.add(okButton);
+				getRootPane().setDefaultButton(okButton);
+			}
+			{
+				JButton cancelButton = new JButton("Salir");
+				cancelButton.addActionListener(new ActionListener() {
+					public void actionPerformed(ActionEvent e) {
+						dispose();
+					}
+				});
+				cancelButton.setActionCommand("Cancel");
+				buttonPane.add(cancelButton);
+			}
+		}
+	}
+	public void clear() {
+		txtNombre.setText("");
+		txtEntrenador.setText("");
+		txtEstadio.setText("");
+		spnPresupuesto.setValue(1000.0);
+	}
+}


### PR DESCRIPTION
* La interfaz principal se puede reutilizar para mostrar juegos de la semana o jugadores destacados.
* La ventana para registrar equipo tendrá la funcionalidad de modificar una vez que se puedan enlistar los equipos registrados.
* También se modifica la clase lógica Equipo para que funcione correctamente con los datos suplidos.
** Los juegos ganados y perdidos son 0 cuando se crea un equipo, sin embargo se puede decidir si serán modificables después de ser creados.